### PR TITLE
Error since include was written agains a case insensitive file system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ INCLUDE(IrrlichtVersion)
 INCLUDE(IrrlichtSource)
 
 # Load compiler dependent settings...
-INCLUDE(CompilerGCCLikeSettings)
+INCLUDE(CompilerGccLikeSettings)
 INCLUDE(CompilerMSVCLikeSettings)
 
 # Load os dependent settings...


### PR DESCRIPTION
The file is called [`CompilerGccLikeSettings.cmake`](https://github.com/ZahlGraf/IrrlichtCMake/blob/master/CMake/Compiler/CompilerGccLikeSettings.cmake) but the include was for `CompilerGCCLikeSettings`
